### PR TITLE
wizard: default to secure password storage over plaintext

### DIFF
--- a/src/terminal/wizard/imap.rs
+++ b/src/terminal/wizard/imap.rs
@@ -35,7 +35,7 @@ static SECRETS: &[&str] = &[
 const CMD: &str = "Use a shell command to retrieve my password (recommended)";
 #[cfg(feature = "keyring")]
 const KEYRING: &str = "Ask my password, then save it in my system's global keyring";
-const RAW: &str = "Save password in the configuration file (⚠ plaintext, not recommended)";
+const RAW: &str = "Save password in the configuration file (plaintext, NOT recommended)";
 
 /// Returns a platform-appropriate default command for retrieving a
 /// password from the system's secret store.

--- a/src/terminal/wizard/imap.rs
+++ b/src/terminal/wizard/imap.rs
@@ -47,7 +47,7 @@ fn default_secret_cmd(account_name: &str, protocol: &str) -> String {
     } else if cfg!(target_os = "linux") {
         format!("secret-tool lookup account {account_name} service himalaya-{protocol}")
     } else {
-        format!("pass show {account_name}")
+        String::new()
     }
 }
 

--- a/src/terminal/wizard/imap.rs
+++ b/src/terminal/wizard/imap.rs
@@ -26,16 +26,30 @@ static ENCRYPTIONS: Lazy<[Encryption; 3]> = Lazy::new(|| {
 });
 
 static SECRETS: &[&str] = &[
-    RAW,
+    CMD,
     #[cfg(feature = "keyring")]
     KEYRING,
-    CMD,
+    RAW,
 ];
 
-const RAW: &str = "Ask my password, then save it in the configuration file (not safe)";
+const CMD: &str = "Use a shell command to retrieve my password (recommended)";
 #[cfg(feature = "keyring")]
 const KEYRING: &str = "Ask my password, then save it in my system's global keyring";
-const CMD: &str = "Ask me a shell command that exposes my password";
+const RAW: &str = "Save password in the configuration file (⚠ plaintext, not recommended)";
+
+/// Returns a platform-appropriate default command for retrieving a
+/// password from the system's secret store.
+fn default_secret_cmd(account_name: &str, protocol: &str) -> String {
+    if cfg!(target_os = "macos") {
+        format!(
+            "security find-generic-password -a '{account_name}' -s 'himalaya-{account_name}-{protocol}' -w"
+        )
+    } else if cfg!(target_os = "linux") {
+        format!("secret-tool lookup account {account_name} service himalaya-{protocol}")
+    } else {
+        format!("pass show {account_name}")
+    }
+}
 
 // TODO: TLS provider
 pub async fn start(
@@ -282,10 +296,10 @@ pub(crate) async fn configure_passwd(account_name: &str) -> Result<ImapAuthConfi
             secret
         }
         &RAW => Secret::new_raw(prompt::password("IMAP password:")?),
-        &CMD => Secret::new_command(prompt::text(
-            "Shell command:",
-            Some(&format!("pass show {account_name}")),
-        )?),
+        &CMD => {
+            let default_cmd = default_secret_cmd(account_name, "imap");
+            Secret::new_command(prompt::text("Shell command:", Some(&default_cmd))?)
+        }
         _ => unreachable!(),
     };
 

--- a/src/terminal/wizard/smtp.rs
+++ b/src/terminal/wizard/smtp.rs
@@ -35,7 +35,7 @@ static SECRETS: &[&str] = &[
 const CMD: &str = "Use a shell command to retrieve my password (recommended)";
 #[cfg(feature = "keyring")]
 const KEYRING: &str = "Ask my password, then save it in my system's global keyring";
-const RAW: &str = "Save password in the configuration file (⚠ plaintext, not recommended)";
+const RAW: &str = "Save password in the configuration file (plaintext, NOT recommended)";
 
 /// Returns a platform-appropriate default command for retrieving a
 /// password from the system's secret store.

--- a/src/terminal/wizard/smtp.rs
+++ b/src/terminal/wizard/smtp.rs
@@ -47,7 +47,7 @@ fn default_secret_cmd(account_name: &str, protocol: &str) -> String {
     } else if cfg!(target_os = "linux") {
         format!("secret-tool lookup account {account_name} service himalaya-{protocol}")
     } else {
-        format!("pass show {account_name}")
+        String::new()
     }
 }
 

--- a/src/terminal/wizard/smtp.rs
+++ b/src/terminal/wizard/smtp.rs
@@ -26,16 +26,30 @@ static ENCRYPTIONS: Lazy<[Encryption; 3]> = Lazy::new(|| {
 });
 
 static SECRETS: &[&str] = &[
-    RAW,
+    CMD,
     #[cfg(feature = "keyring")]
     KEYRING,
-    CMD,
+    RAW,
 ];
 
-const RAW: &str = "Ask my password, then save it in the configuration file (not safe)";
+const CMD: &str = "Use a shell command to retrieve my password (recommended)";
 #[cfg(feature = "keyring")]
 const KEYRING: &str = "Ask my password, then save it in my system's global keyring";
-const CMD: &str = "Ask me a shell command that exposes my password";
+const RAW: &str = "Save password in the configuration file (⚠ plaintext, not recommended)";
+
+/// Returns a platform-appropriate default command for retrieving a
+/// password from the system's secret store.
+fn default_secret_cmd(account_name: &str, protocol: &str) -> String {
+    if cfg!(target_os = "macos") {
+        format!(
+            "security find-generic-password -a '{account_name}' -s 'himalaya-{account_name}-{protocol}' -w"
+        )
+    } else if cfg!(target_os = "linux") {
+        format!("secret-tool lookup account {account_name} service himalaya-{protocol}")
+    } else {
+        format!("pass show {account_name}")
+    }
+}
 
 pub async fn start(
     account_name: impl AsRef<str>,
@@ -278,10 +292,10 @@ pub(crate) async fn configure_passwd(account_name: &str) -> Result<SmtpAuthConfi
             secret
         }
         &RAW => Secret::new_raw(prompt::password("SMTP password:")?),
-        &CMD => Secret::new_command(prompt::text(
-            "Shell command:",
-            Some(&format!("pass show {account_name}")),
-        )?),
+        &CMD => {
+            let default_cmd = default_secret_cmd(account_name, "smtp");
+            Secret::new_command(prompt::text("Shell command:", Some(&default_cmd))?)
+        }
         _ => unreachable!(),
     };
 


### PR DESCRIPTION
## Summary

The IMAP and SMTP account configuration wizards currently default to saving passwords in plaintext in the config file (`auth.raw`). This PR reorders the options to default to the shell command approach (`auth.cmd`) instead, nudging users toward secure credential storage.

## Problem

When running `himalaya account configure`, the first (default) option is:
> "Ask my password, then save it in the configuration file (not safe)"

Since the `keyring` feature is not included in the default `brew install himalaya` or basic `cargo install`, most users end up with plaintext passwords on disk at `~/.config/himalaya/config.toml`.

## Changes

- **Reorder `SECRETS` array**: CMD > KEYRING > RAW (was RAW > KEYRING > CMD)
- **Update labels** to clearly mark CMD as recommended and RAW as not recommended
- **Platform-aware default commands** when CMD is selected:
  - **macOS**: `security find-generic-password` (Keychain)
  - **Linux**: `secret-tool lookup` (GNOME Keyring / libsecret)
  - **Fallback**: empty string for unsupported platforms
- Same changes applied to both IMAP and SMTP wizards

## Before

```
IMAP authentication strategy:
> Ask my password, then save it in the configuration file (not safe)
  Ask me a shell command that exposes my password
```

## After

```
IMAP authentication strategy:
> Use a shell command to retrieve my password (recommended)
  Save password in the configuration file (plaintext, NOT recommended)
```

When selecting CMD on macOS, the default suggestion is now:
```
security find-generic-password -a 'account-name' -s 'himalaya-account-name-imap' -w
```

## Motivation

Discovered this while setting up himalaya on macOS. The wizard generated `auth.raw` with a plaintext password by default. Switching to `auth.cmd` with macOS Keychain (`security find-generic-password`) was straightforward and keeps credentials encrypted at rest. This should be the default path for new users.